### PR TITLE
feat: Validation de vue peut retournée une valeur objet complexe

### DIFF
--- a/js/src/EditView.js
+++ b/js/src/EditView.js
@@ -3,7 +3,7 @@
 import View from './View';
 import SaveDialog from "./SaveDialog";
 import FetchService, {FetchAbortError, FetchResponseDataError} from './FetchService';
-import {ValidateStepCallback, ValidateResponse} from './types';
+import type {ValidateStepCallback, ValidateResponse} from './types';
 
 declare var $: jQuery;
 

--- a/js/src/types.js
+++ b/js/src/types.js
@@ -1,0 +1,7 @@
+//@flow
+
+export type ValidateResponse = {
+	ok: boolean;
+} | boolean;
+
+export type ValidateStepCallback = () => Promise<ValidateResponse>;


### PR DESCRIPTION
Les validation de vue peuvent maintenant retourner des objet complexe de staut.

`{ ok: true}` indique que la validation est passé.

Changement backward compatible.  Le retour d'un boolean fonctionne toujours.