### PR TITLE
fix: Meilleur gestion et journalisation des erreurs de fetch

### DIFF
--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -1647,7 +1647,7 @@ export default class Application extends EventEmitter{
 		self.showModalDialog(self.getShowErrorHTML(message), 'fast')
 			.then($dialog => {
 				$dialog.find('#hook_create_error_close').safeClick(() => {
-					this.hideModalDialog('fast').then(resolveDialog());
+					this.hideModalDialog('fast').then(resolveDialog);
 				});
 			});
 

--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -2607,7 +2607,7 @@ export default class Application extends EventEmitter{
 			showLoading,
 			showOverlay: (!showLoading && !skipOverlayHandling)
 		};
-		this.fetch(this.getViewUrl(view, cmd, paramsString), options)
+		return this.fetch(this.getViewUrl(view, cmd, paramsString), options)
 			.then(FetchService.parseJSON)
 			.then(FetchService.handleApplicationResponseData)
 			.then((data) => {
@@ -2626,7 +2626,7 @@ export default class Application extends EventEmitter{
 			showOverlay: (!showLoading && !skipOverlayHandling)
 		};
 		options = FetchService.addPostOptions(postString, options);
-		this.fetch(this.getViewUrl(view, cmd, paramsString), options)
+		return this.fetch(this.getViewUrl(view, cmd, paramsString), options)
 			.then(FetchService.parseJSON)
 			.then(FetchService.handleApplicationResponseData)
 			.then((data) => {


### PR DESCRIPTION
Ce PR traite principalement les cas ou l'application traite une erreur suite à une opération fetch et qu'elle affiche le dialogue d'erreur à l'usager.

Cela touche principalement la fonction `Application.handleFetchError()`

- Journaliser l'erreur dans la console de dev et dans sentry
- Ne pas journaliser les erreurs 2 fois (dans la console ou dans sentry)
- Faire remoter les exceptions dans la chaine de promesse pour s'assurer que chaque traitement de la chaine fait son cleanup.
- Ajoute des fonctions utilitaire pour tester les erreurs
- showErreur retourne une promesse lorsque le dialogue est fermé par l'utilisateur. (non utilisé mais éventuellement utile)
