### PR TITLE
CRM-10255: fix(ShowModalDialog): Remove z-index overwrite

### DIFF
--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -1478,7 +1478,7 @@ export default class Application extends EventEmitter{
 	 */
 	showModalDialog(content, speed, callback, width): Promise<jQuery> {
 		const self = this;
-		this.showOverlay('rgba(0, 0, 0, 0.4)', 1, 'overlay', 1);
+		this.showOverlay('rgba(0, 0, 0, 0.4)', 1, 'overlay');
 
 		let $modalDialog = $('<div></div>')
 			.attr('id', 'modal_dialog')


### PR DESCRIPTION
La méthode `showModalDialog` overwrite les styles définis pour les overlays avec la méthode `showOverlay`. J'ai retiré le z-index overwrite par défaut afin de permettre aux styles dans le CRM de passer sur les overlays. Une autre PR a été ouverte de kronos-crm pour augmenter le z-index des overlays

[PR dans kronos-crm](https://github.com/kronostechnologies/kronos-crm/pull/6020#issue-541446455)

[Carte Jira](https://jira.equisoft.com/browse/CRM-10255?workflowName=CRM+Dev+Workflow+-+3.0&stepId=33)