### PR TITLE
CRM-13681: Fixes handledByApplication error on fetch error handling

### DIFF
--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -2198,8 +2198,11 @@ export default class Application extends EventEmitter{
 			this.showError(errorMessage);
 		}
 
-		// Special flag to avoid loging error twice
-		error.handledByApplication = true;
+		if (!this.isErrorObject(error)) {
+		    // Special flag to avoid logging error twice
+                   error.handledByApplication = true;
+		}
+
 		throw error;
 	}
 
@@ -2208,11 +2211,15 @@ export default class Application extends EventEmitter{
 	}
 
 	isFetchResponseDataError(error) {
-		return typeof error === 'object' && error instanceof FetchResponseDataError;
+		return this.isErrorObject(error) && error instanceof FetchResponseDataError;
 	}
 
 	isErrorAlreadyHandled(error) {
-		return typeof error === 'object' && error.handledByApplication === true;
+		return this.isErrorObject(error) && error.handledByApplication === true;
+	}
+
+	isErrorObject(error) {
+	    return typeof error === 'object';
 	}
 
 	datepicker(selector, options) {


### PR DESCRIPTION
https://jira.equisoft.com/browse/CRM-13681

Y'a bon nombre d'erreurs que Sentry nous envoie qui ont pas rapport avec le comportement créant l'erreur; En fait c'est la promesse qui plante en voulant attribuer une prop à la string d'erreur:

```
{
extra: {
arguments: [
Unhandled promise rejection:, 
TypeError: Cannot create property 'handledByApplication' on string ''
    at _e.value (https://secure.kronos-web.com/crm/js/bundle/npm.kronos-app-frontend.acec0c8698f2fa628aa8.chunk.js:16:38484)
    at i.value (https://secure.kronos-web.com/crm/js/bundle/25.b38aa76ded0fd7a80889.chunk.js:1:114029)
]
}, 
logger: console
}
```


Fixer ça va permettre des logs d'erreur beaucoup plus pertinent (et probablement moins nombreux) à l'avenir.