### PR TITLE
CRM-15883/ contacts - prevent exceptions when private

### DIFF
--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -462,6 +462,12 @@ export default class Application extends EventEmitter {
         return false;
     }
 
+    /** over-ridden in kronos-crm/app/views/App/Application.js */
+    _showAccessDeniedError(traceId) {
+        const self = this;
+        self._showFatalError('', traceId);
+    }
+
     _showNavigationError() {
         const self = this;
         self.showModalDialog(`<h2>${self._('NAVIGATION_ERROR')}</h2>\
@@ -858,6 +864,8 @@ export default class Application extends EventEmitter {
                                 traceId);
                         } else if (info.code == 601 || info.code == 602) { // VIEW_ACL_ERROR or MODEL_ACL_ERROR
                             self._showNavigationError();
+                        } else if (info.code == 604) {
+                            self._showAccessDeniedError(traceId);
                         } else { // Unknown error
                             self._showFatalError(`An unknown error was sent from server while fetching view data "${view}" (${info.error})`,
                                 traceId);


### PR DESCRIPTION
[CRM-15883](https://jira.equisoft.com/browse/CRM-15883)

Empêcher les exceptions lors de l'affichage du contact d'un autre utilisateur s'il est "privé"

Tests fonctionnels :
- l'utilisateur ne voit pas de message d'erreur si le contact qu'il regarde lui appartient et est privé
- l'utilisateur voit un message d'erreur si le contact qu'il regarde ne lui appartient pas et est privé
- aucune exception n'est crée dans Sentry