### PR TITLE
CRM-19963: Sentry - Le frontend log ACCP comme étant PROD

### DIFF
--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -223,9 +223,10 @@ export default class Application extends EventEmitter {
         if (config && config.sentry) {
             Sentry.init({
                 dsn: config.sentry.dsn,
-                release: config.application_version,
+                release: `${config.sentry.projectName}@${config.application_version}`,
                 beforeSend: this.sentry_beforeSend.bind(this),
-                sendDefaultPii: true
+                sendDefaultPii: true,
+                environment: config.sentry.environment
             });
 
             Sentry.configureScope((scope) => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@equisoft/eslint-config": "3.0.3",
     "@microsoft/eslint-formatter-sarif": "3.0.0",
     "@xmldom/xmldom": "0.8.7",
-    "@babel/eslint-parser": "7.21.3",
     "babel-loader": "9.1.2",
     "blob-polyfill": "7.0.20220408",
     "chai": "4.3.7",


### PR DESCRIPTION
[CRM-19963](https://jira.equisoft.com/browse/CRM-19963)

J'ai changé comment le param `release` est écrit pour match le backend et j'ai ajouté le param `environment`.