### PR TITLE
CRM-15587: Ignore benign ResizeObserver error in Sentry

### DIFF
--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -2469,6 +2469,15 @@ export default class Application extends EventEmitter {
                 });
                 return null;
             }
+            // Ignore benign error: https://github.com/WICG/resize-observer/issues/38
+            if (hint.originalException.message === 'ResizeObserver loop limit exceeded') {
+                // Don't trigger an error for that but keep a trace.
+                Sentry.addBreadcrumb({
+                    message: 'ResizeObserver loop limit exceeded',
+                    level: 'warning',
+                });
+                return null;
+            }
         }
 
         return event;


### PR DESCRIPTION
[CRM-15587](https://jira.equisoft.com/browse/CRM-15587)

L'erreur `ResizeObserver loop limit exceeded` survient lorsque le ResizeObserver ne peut livrer l'ensemble de ses observations à l'intérieur d'un animationFrame. C'est une erreur bénigne et elle n'est pas lancée par notre code.

La solution est simplement de l'ignorer dans la config Sentry.