### PR TITLE
CRM-14907: UnhandledRejection: Non-Error promise rejection captured with value:

### DIFF
--- a/js/src/Application.js
+++ b/js/src/Application.js
@@ -173,8 +173,7 @@ export default class Application extends EventEmitter {
             return;
         }
 
-        const reason = event.reason;
-        this.logError('Unhandled promise rejection', event.reason);
+        this.logError('Unhandled promise rejection', error);
     }
 
     logError(error_title, error) {
@@ -2475,6 +2474,15 @@ export default class Application extends EventEmitter {
                 // Don't trigger an error for that but keep a trace.
                 Sentry.addBreadcrumb({
                     message: 'ResizeObserver loop limit exceeded',
+                    level: 'warning',
+                });
+                return null;
+            }
+            // Ignore benign error: https://github.com/getsentry/sentry-javascript/issues/3440
+            if (hint.originalException.message === 'Non-Error promise rejection captured with value:') {
+                // Don't trigger an error for that but keep a trace.
+                Sentry.addBreadcrumb({
+                    message: 'Non-Error promise rejection captured with no value',
                     level: 'warning',
                 });
                 return null;


### PR DESCRIPTION
[CRM-14907](https://jira.equisoft.com/browse/CRM-14907)

L'erreur est causé par la fonction `Safe Link` de Microsoft. La solution est d'ignoré l'erreur ou de convaincre Microsoft de ne plus envoyer l'erreur. (Je choisis d'ignorer l'erreur)

Source: https://github.com/getsentry/sentry-javascript/issues/3440